### PR TITLE
ORC: bump to 1.9.8

### DIFF
--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/orc/OrcReadTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/orc/OrcReadTest.java
@@ -168,7 +168,7 @@ public class OrcReadTest extends BaseFeature {
      * TODO Do we need to do some changes to make sure the external-table behaves the same way as GPDB/FDW?
      *
      */
-    @FailsWithFDW
+    // FIXME
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void orcReadStringsContainingNullByte() throws Exception {
         prepareReadableExternalTable("pxf_orc_null_in_string", ORC_NULL_IN_STRING_COLUMNS, hdfsPath + ORC_NULL_IN_STRING);

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -78,7 +78,7 @@ configure(javaProjects) {
             dependency("com.fasterxml.woodstox:woodstox-core:5.0.3")
             dependency("com.google.code.findbugs:annotations:1.3.9")
             dependency("com.google.guava:guava:20.0")
-            dependency("com.google.protobuf:protobuf-java:2.5.0")
+            dependency("com.google.protobuf:protobuf-java:3.25.8")
             dependency("com.google.cloud.bigdataoss:gcs-connector:hadoop2-1.9.17")
             dependency("com.microsoft.azure:azure-storage:5.5.0")
             dependency("com.microsoft.azure:azure-data-lake-store-sdk:2.3.9")

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -28,4 +28,4 @@ awsJavaSdk=1.12.261
 springBootVersion=2.7.18
 org.gradle.daemon=true
 org.gradle.parallel=false
-orcVersion=1.6.13
+orcVersion=1.9.8


### PR DESCRIPTION
Bump apache orc library to 1.9.8 (latest java 8 compatible version)