### PR TITLE
CI: cache cloudberry DEB and RPM builds for one months

### DIFF
--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -95,6 +95,7 @@ jobs:
         tar czf cloudberry-source.tar.gz cloudberry/
 
     - name: Save DEB cache
+      # save cache from default branch only (this cache can be reused between PRs)
       if: steps.cache-deb.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
@@ -124,7 +125,7 @@ jobs:
       image: apache/incubator-cloudberry:cbdb-build-rocky9-latest
       options: --user root
     steps:
-    - name: Get week number
+    - name: Get month number
       id: get-month
       run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
 
@@ -167,6 +168,7 @@ jobs:
         tar czf cloudberry-source-rocky9.tar.gz cloudberry/
 
     - name: Save RPM cache
+      # save cache from default branch only (this cache can be reused between PRs)
       if: steps.cache-rpm.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -65,12 +65,6 @@ jobs:
           workspace/cloudberry-source.tar.gz
         key: cloudberry-deb-${{ runner.os }}-${{ steps.get-month.outputs.month }}
 
-    - name: Checkout PXF source (for build script)
-      if: steps.cache-deb.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
-      with:
-        path: cloudberry-pxf
-
     - name: Checkout Cloudberry source
       if: steps.cache-deb.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
@@ -79,6 +73,12 @@ jobs:
         ref: ${{ env.CLOUDBERRY_VERSION }}
         path: workspace/cloudberry
         submodules: true
+
+    - name: Checkout PXF source (for build script)
+      if: steps.cache-deb.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        path: cloudberry-pxf
 
     - name: Build Cloudberry DEB
       if: steps.cache-deb.outputs.cache-hit != 'true'
@@ -137,12 +137,6 @@ jobs:
           workspace/cloudberry-source-rocky9.tar.gz
         key: cloudberry-rpm-${{ runner.os }}-${{ steps.get-month.outputs.month }}
 
-    - name: Checkout PXF source (for build script)
-      if: steps.cache-rpm.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
-      with:
-        path: cloudberry-pxf
-
     - name: Checkout Cloudberry source
       if: steps.cache-rpm.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
@@ -151,6 +145,12 @@ jobs:
         ref: ${{ env.CLOUDBERRY_VERSION }}
         path: workspace/cloudberry
         submodules: true
+
+    - name: Checkout PXF source (for build script)
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        path: cloudberry-pxf
 
     - name: Build Cloudberry RPM
       if: steps.cache-rpm.outputs.cache-hit != 'true'

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -52,7 +52,27 @@ jobs:
       image: apache/incubator-cloudberry:cbdb-build-ubuntu22.04-latest
       options: --user root
     steps:
+    - name: Get week number
+      id: get-month
+      run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
+
+    - name: Restore DEB cache
+      id: cache-deb
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          workspace/cloudberry-deb
+          workspace/cloudberry-source.tar.gz
+        key: cloudberry-deb-${{ runner.os }}-${{ steps.get-month.outputs.month }}
+
+    - name: Checkout PXF source (for build script)
+      if: steps.cache-deb.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        path: cloudberry-pxf
+
     - name: Checkout Cloudberry source
+      if: steps.cache-deb.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
         repository: apache/cloudberry
@@ -60,12 +80,8 @@ jobs:
         path: workspace/cloudberry
         submodules: true
 
-    - name: Checkout PXF source (for build script)
-      uses: actions/checkout@v4
-      with:
-        path: cloudberry-pxf
-
     - name: Build Cloudberry DEB
+      if: steps.cache-deb.outputs.cache-hit != 'true'
       run: |
         export WORKSPACE=$PWD/workspace
         export CLOUDBERRY_VERSION=99.0.0
@@ -73,9 +89,19 @@ jobs:
         bash cloudberry-pxf/ci/docker/pxf-cbdb-dev/ubuntu/script/build_cloudberry_deb.sh
 
     - name: Package Cloudberry source
+      if: steps.cache-deb.outputs.cache-hit != 'true'
       run: |
         cd workspace
         tar czf cloudberry-source.tar.gz cloudberry/
+
+    - name: Save DEB cache
+      if: steps.cache-deb.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          workspace/cloudberry-deb
+          workspace/cloudberry-source.tar.gz
+        key: cloudberry-deb-${{ runner.os }}-${{ steps.get-month.outputs.month }}
 
     - name: Upload DEB artifact
       uses: actions/upload-artifact@v4
@@ -98,7 +124,27 @@ jobs:
       image: apache/incubator-cloudberry:cbdb-build-rocky9-latest
       options: --user root
     steps:
+    - name: Get week number
+      id: get-month
+      run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
+
+    - name: Restore RPM cache
+      id: cache-rpm
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          workspace/cloudberry-rpm
+          workspace/cloudberry-source-rocky9.tar.gz
+        key: cloudberry-rpm-${{ runner.os }}-${{ steps.get-month.outputs.month }}
+
+    - name: Checkout PXF source (for build script)
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        path: cloudberry-pxf
+
     - name: Checkout Cloudberry source
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
         repository: apache/cloudberry
@@ -106,12 +152,8 @@ jobs:
         path: workspace/cloudberry
         submodules: true
 
-    - name: Checkout PXF source (for build script)
-      uses: actions/checkout@v4
-      with:
-        path: cloudberry-pxf
-
     - name: Build Cloudberry RPM
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
       run: |
         export WORKSPACE=$PWD/workspace
         export CLOUDBERRY_VERSION=99.0.0
@@ -119,9 +161,19 @@ jobs:
         bash cloudberry-pxf/ci/docker/pxf-cbdb-dev/rocky9/script/build_cloudberry_rpm.sh
 
     - name: Package Cloudberry source
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
       run: |
         cd workspace
         tar czf cloudberry-source-rocky9.tar.gz cloudberry/
+
+    - name: Save RPM cache
+      if: steps.cache-rpm.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          workspace/cloudberry-rpm
+          workspace/cloudberry-source-rocky9.tar.gz
+        key: cloudberry-rpm-${{ runner.os }}-${{ steps.get-month.outputs.month }}
 
     - name: Upload RPM artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -95,7 +95,7 @@ jobs:
         tar czf cloudberry-source.tar.gz cloudberry/
 
     - name: Save DEB cache
-      if: steps.cache-deb.outputs.cache-hit != 'true'
+      if: steps.cache-deb.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -167,7 +167,7 @@ jobs:
         tar czf cloudberry-source-rocky9.tar.gz cloudberry/
 
     - name: Save RPM cache
-      if: steps.cache-rpm.outputs.cache-hit != 'true'
+      if: steps.cache-rpm.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/workflows/pxf-ci.yml
+++ b/.github/workflows/pxf-ci.yml
@@ -52,7 +52,7 @@ jobs:
       image: apache/incubator-cloudberry:cbdb-build-ubuntu22.04-latest
       options: --user root
     steps:
-    - name: Get week number
+    - name: Get month number
       id: get-month
       run: echo "month=$(/bin/date -u '+%Y-%m')" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
**Cache CPU-heavy CI steps:**
* DEB build
* RPM build

This should speed up our CI pipelines and reduce github actions quota usage.

**Implementations details:**
* Github cache has 7 days TTL. Every build will reset expiration timeout. In order to force CI to build cloudberry from time to time - I am explicitly specifying current month in a cache key.
* keep both: `actions/cache` and `actions/actions/upload-artifact`. In case cache eviction happens during build (e.g. hit 10Gb limit) we will still have running builds.
* cache reused between `main` and other PRs (but not between PRs). So, cache will be filled only during builds in `main`.