### PR TITLE
fix: Fragmenter consumes all memory during S3 bucket listing

### DIFF
--- a/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/cloud/S3FragmentLimitTest.java
+++ b/automation/src/test/java/org/apache/cloudberry/pxf/automation/features/cloud/S3FragmentLimitTest.java
@@ -1,0 +1,120 @@
+package org.apache.cloudberry.pxf.automation.features.cloud;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.cloudberry.pxf.automation.AbstractTestcontainersTest;
+import org.apache.cloudberry.pxf.automation.applications.S3Application;
+import org.apache.cloudberry.pxf.automation.structures.tables.pxf.ReadableExternalTable;
+import org.apache.cloudberry.pxf.automation.testcontainers.MinIOContainer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+/**
+ * End-to-end test for the per-table {@code FILES_LIMIT} option (backed
+ * by the {@code pxf.fs.fragmenter.files.limit} property): a query over
+ * an S3 prefix that matches more files than the limit must fail with a clear
+ * error instead of risking an out-of-memory while listing.
+ */
+public class S3FragmentLimitTest extends AbstractTestcontainersTest {
+
+    private static final String[] SINGLE_INT_COLUMN = {"n int"};
+
+    private MinIOContainer s3Server;
+    private S3Application s3Application;
+    private String bucket;
+    private String prefix;
+    private String wildcardLocation;
+
+    @Override
+    public void beforeClass() throws Exception {
+        s3Server = new MinIOContainer(container.getSharedNetwork());
+        s3Server.start();
+        s3Application = new S3Application(s3Server);
+
+        bucket = MinIOContainer.DEFAULT_BUCKET;
+        s3Application.createBucket(bucket);
+
+        prefix = "fragment-limit/" + UUID.randomUUID() + "/";
+        uploadLine("a.txt", "10");
+        uploadLine("b.txt", "20");
+        wildcardLocation = "/" + bucket + "/" + prefix + "*.txt";
+    }
+
+    @Override
+    public void afterClass() throws Exception {
+        if (s3Application != null) {
+            if (prefix != null) {
+                s3Application.deletePrefix(bucket, prefix);
+            }
+            s3Application.shutdown();
+        }
+        if (s3Server != null) {
+            s3Server.stop();
+        }
+    }
+
+    @Test(groups = {"testcontainers", "pxf-s3"})
+    public void testReadFailsWhenFilesExceedLimit() throws Exception {
+        ReadableExternalTable table = externalTable("fragment_limit_exceeded", "FILES_LIMIT=1");
+        cloudberry.createTableAndVerify(table);
+
+        try {
+            cloudberry.runQuery("SELECT * FROM " + table.getName());
+            Assert.fail("Query should have failed because the prefix matches more files than the limit");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("exceeds the configured limit"),
+                    "Unexpected error message: " + e.getMessage());
+        }
+    }
+
+    @Test(groups = {"testcontainers", "pxf-s3"})
+    public void testReadSucceedsWhenWithinLimit() throws Exception {
+        ReadableExternalTable table = externalTable("fragment_limit_within", "FILES_LIMIT=10");
+        cloudberry.createTableAndVerify(table);
+
+        // The two files are within the limit; the streaming listing must return
+        // them without error.
+        cloudberry.runQuery("SELECT count(*) FROM " + table.getName());
+    }
+
+    private ReadableExternalTable externalTable(String name, String... userParameters) {
+        ReadableExternalTable table = new ReadableExternalTable(name, SINGLE_INT_COLUMN, wildcardLocation, "CSV");
+        table.setProfile("s3:csv");
+        table.setServer("server=s3");
+        table.setHost(pxfHost);
+        table.setPort(pxfPort);
+        table.setUserParameters(userParameters);
+        return table;
+    }
+
+    private void uploadLine(String filename, String content) throws Exception {
+        Path tempFile = Files.createTempFile("pxf-fragment-limit-", ".txt");
+        try {
+            Files.write(tempFile, (content + "\n").getBytes());
+            s3Application.putObject(bucket, prefix + filename, tempFile);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+}

--- a/docs/access-objectstores/access_objstore.md
+++ b/docs/access-objectstores/access_objstore.md
@@ -120,3 +120,34 @@ CREATE EXTERNAL TABLE pxf_gsc_json(location text, month text, num_orders int, to
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 </pre>
 
+## Limiting the Number of Files Read
+
+When you query an external table that references a directory or a wildcard, PXF lists all of the matching files before it reads any data. On an object store, a path or wildcard can match a very large number of objects; listing them can consume significant memory on the PXF server and, in extreme cases, fail with an out-of-memory error that is difficult to interrupt.
+
+To guard against this, PXF caps the number of files that a single read request may resolve when accessing an object store with the `s3:*`, `gs:*`, `wasbs:*`, and `abfss:*` profiles. When a query matches more files than the limit, it fails with an error similar to:
+
+```
+The number of files to process exceeds the configured limit of <N>. Raise the FILES_LIMIT external table option or the pxf.fs.fragmenter.files.limit server property, or narrow the path or wildcard.
+```
+
+The default limit is 10000000 (ten million) files. You can change it in either of the following ways, listed from highest to lowest precedence:
+
+1. Per external table, with the `FILES_LIMIT` option in the `LOCATION` URI. For example, to allow at most 500000 files for a single table:
+
+    <pre>
+    CREATE EXTERNAL TABLE pxf_s3_many_files(location text, month text, num_orders int, total_sales float8)
+      LOCATION ('pxf://S3_BUCKET/pxf_examples/*.parquet?<b>PROFILE=s3:parquet&SERVER=s3srvcfg&FILES_LIMIT=500000</b>')
+    FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    </pre>
+
+2. Per server, with the `pxf.fs.fragmenter.files.limit` property in the server's `pxf-site.xml` configuration file:
+
+    <pre>
+    &lt;property&gt;
+        &lt;name&gt;pxf.fs.fragmenter.files.limit&lt;/name&gt;
+        &lt;value&gt;500000&lt;/value&gt;
+    &lt;/property&gt;
+    </pre>
+
+Set the value to `0`, or to a negative number, to disable the limit. The limit applies only to object stores; reads from HDFS and the local file system are not affected.
+

--- a/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/HcfsType.java
+++ b/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/HcfsType.java
@@ -45,8 +45,10 @@ public enum HcfsType {
     },
     GS,
     HDFS,
+    @Deprecated
     S3,
     S3A,
+    @Deprecated
     S3N,
     // We prefer WASBS over WASB for Azure Blob Storage,
     // as it uses SSL for communication to Azure servers
@@ -72,6 +74,24 @@ public enum HcfsType {
                 .filter(v -> v.name().equals(s))
                 .findFirst()
                 .orElse(HcfsType.CUSTOM);
+    }
+
+    /**
+     * @return true if this type refers to an object store (S3, GCS, Azure),
+     * where a directory/prefix may contain an unbounded number of objects.
+     */
+    public boolean isObjectStore() {
+        switch (this) {
+            case S3:
+            case S3A:
+            case S3N:
+            case GS:
+            case ABFSS:
+            case WASBS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     /**

--- a/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -132,6 +132,11 @@ public class HdfsDataFragmenter extends BaseFragmenter {
     protected JobConf getJobConf() {
         if (jobConf == null) {
             jobConf = new JobConf(configuration, this.getClass());
+            // Inject Table DDL options into jobConf
+            if (context.getOption(PxfInputFormat.FILES_LIMIT_OPTION) != null) {
+                jobConf.setInt(PxfInputFormat.FILES_LIMIT_PROPERTY,
+                        context.getOption(PxfInputFormat.FILES_LIMIT_OPTION, PxfInputFormat.DEFAULT_FILES_LIMIT));
+            }
         }
         return jobConf;
     }

--- a/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/utilities/PxfInputFormat.java
+++ b/server/pxf-hdfs/src/main/java/org/apache/cloudberry/pxf/plugins/hdfs/utilities/PxfInputFormat.java
@@ -19,19 +19,28 @@ package org.apache.cloudberry.pxf.plugins.hdfs.utilities;
  * under the License.
  */
 
+import org.apache.cloudberry.pxf.plugins.hdfs.HcfsType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.GlobFilter;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.io.compress.SplittableCompressionCodec;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * PxfInputFormat is not intended to read a specific format, hence it implements
@@ -42,6 +51,21 @@ import java.io.IOException;
  */
 public class PxfInputFormat extends FileInputFormat {
 
+    /**
+     * Limits the number of files a single fragmenter request will resolve. On
+     * object stores a wildcard or a directory may match an unbounded number of
+     * objects, and {@link FileSystem#globStatus} materializes them all into one
+     * array, which can exhaust the heap. A non-positive value disables the limit.
+     */
+    public static final String FILES_LIMIT_PROPERTY = "pxf.fs.fragmenter.files.limit";
+    public static final String FILES_LIMIT_OPTION = "FILES_LIMIT";
+    public static final int DEFAULT_FILES_LIMIT = 10_000_000;
+
+    private static final PathFilter HIDDEN_FILE_FILTER = path -> {
+        String name = path.getName();
+        return !name.startsWith("_") && !name.startsWith(".");
+    };
+
     @Override
     public RecordReader getRecordReader(InputSplit split,
                                         JobConf conf,
@@ -51,7 +75,118 @@ public class PxfInputFormat extends FileInputFormat {
 
     @Override
     public FileStatus[] listStatus(JobConf job) throws IOException {
-        return super.listStatus(job);
+        int limit = job.getInt(FILES_LIMIT_PROPERTY, DEFAULT_FILES_LIMIT);
+        if (limit <= 0 || job.getBoolean(INPUT_DIR_RECURSIVE, false) || !isLimitApplicable(job)) {
+            return super.listStatus(job);
+        }
+        return limitedListStatus(job, limit);
+    }
+
+    /**
+     * The limited listing streams a single directory level via a
+     * {@link RemoteIterator}; it can only honor a glob in the terminal path
+     * component on an object store. Anything else is left to the parent's
+     * Globber-based implementation.
+     */
+    protected boolean isLimitApplicable(JobConf job) throws IOException {
+        for (Path path : getInputPaths(job)) {
+            String scheme = path.toUri().getScheme();
+            if (scheme == null || !HcfsType.fromString(scheme.toUpperCase()).isObjectStore()) {
+                return false;
+            }
+            Path parent = path.getParent();
+            if (parent != null && new GlobFilter(parent.toString()).hasPattern()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private FileStatus[] limitedListStatus(JobConf job, int limit) throws IOException {
+        Path[] dirs = getInputPaths(job);
+        if (dirs.length == 0) {
+            throw new IOException("No input paths specified in job");
+        }
+        PathFilter inputFilter = inputFilter(job);
+
+        List<FileStatus> result = new ArrayList<>();
+        List<IOException> errors = new ArrayList<>();
+        for (Path path : dirs) {
+            collectFiles(result, path.getFileSystem(job), path, inputFilter, limit, errors);
+        }
+        if (!errors.isEmpty()) {
+            throw new InvalidInputException(errors);
+        }
+        return result.toArray(new FileStatus[0]);
+    }
+
+    private void collectFiles(List<FileStatus> result, FileSystem fs, Path path,
+                              PathFilter inputFilter, int limit, List<IOException> errors) throws IOException {
+        GlobFilter nameGlob = new GlobFilter(path.getName());
+        Path baseDir;
+        PathFilter glob;
+        if (nameGlob.hasPattern()) {
+            baseDir = path.getParent();
+            glob = nameGlob;
+        } else {
+            FileStatus status;
+            try {
+                status = fs.getFileStatus(path);
+            } catch (FileNotFoundException e) {
+                errors.add(new IOException("Input path does not exist: " + path));
+                return;
+            }
+            if (!status.isDirectory()) {
+                if (inputFilter.accept(status.getPath())) {
+                    add(result, status, limit);
+                }
+                return;
+            }
+            baseDir = path;
+            glob = null;
+        }
+
+        RemoteIterator<LocatedFileStatus> iterator;
+        try {
+            iterator = fs.listLocatedStatus(baseDir);
+        } catch (FileNotFoundException e) {
+            errors.add(new IOException("Input path does not exist: " + path));
+            return;
+        }
+        int matched = 0;
+        while (iterator.hasNext()) {
+            LocatedFileStatus child = iterator.next();
+            if (!inputFilter.accept(child.getPath())) {
+                continue;
+            }
+            if (glob != null && !glob.accept(child.getPath())) {
+                continue;
+            }
+            add(result, child, limit);
+            matched++;
+        }
+        if (matched == 0 && glob != null) {
+            errors.add(new IOException("Input Pattern " + path + " matches 0 files"));
+        }
+    }
+
+    private void add(List<FileStatus> result, FileStatus status, int limit) throws IOException {
+        if (result.size() >= limit) {
+            throw new IOException(String.format(
+                    "The number of files to process exceeds the configured limit of %d. "
+                            + "Raise the %s external table option or the %s server property, "
+                            + "or narrow the path or wildcard.",
+                    limit, FILES_LIMIT_OPTION, FILES_LIMIT_PROPERTY));
+        }
+        result.add(status);
+    }
+
+    private PathFilter inputFilter(JobConf job) {
+        PathFilter jobFilter = getInputPathFilter(job);
+        if (jobFilter == null) {
+            return HIDDEN_FILE_FILTER;
+        }
+        return path -> HIDDEN_FILE_FILTER.accept(path) && jobFilter.accept(path);
     }
 
     /**

--- a/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/HcfsTypeTest.java
+++ b/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/HcfsTypeTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HcfsTypeTest {
 
@@ -28,6 +30,17 @@ public class HcfsTypeTest {
         context = new RequestContext();
         context.setDataSource("/foo/bar.txt");
         context.setConfiguration(configuration);
+    }
+
+    @Test
+    public void testIsObjectStore() {
+        for (HcfsType type : new HcfsType[]{HcfsType.S3, HcfsType.S3A, HcfsType.S3N,
+                HcfsType.GS, HcfsType.ABFSS, HcfsType.WASBS}) {
+            assertTrue(type.isObjectStore(), type + " should be an object store");
+        }
+        for (HcfsType type : new HcfsType[]{HcfsType.HDFS, HcfsType.FILE, HcfsType.CUSTOM}) {
+            assertFalse(type.isObjectStore(), type + " should not be an object store");
+        }
     }
 
     @Test

--- a/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -2,9 +2,11 @@ package org.apache.cloudberry.pxf.plugins.hdfs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.InvalidInputException;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.cloudberry.pxf.api.model.Fragment;
 import org.apache.cloudberry.pxf.api.model.Fragmenter;
 import org.apache.cloudberry.pxf.api.model.RequestContext;
+import org.apache.cloudberry.pxf.plugins.hdfs.utilities.PxfInputFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -81,6 +83,35 @@ public class HdfsDataFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         assertEquals(0, fragmentList.size());
+    }
+
+    @Test
+    public void testFileFragmentsLimitOptionOverridesJobConf() {
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setDataSource("/some/path");
+        context.addOption("FILES_LIMIT", "42");
+
+        HdfsDataFragmenter fragmenter = new HdfsDataFragmenter();
+        fragmenter.setRequestContext(context);
+        fragmenter.afterPropertiesSet();
+
+        JobConf jobConf = fragmenter.getJobConf();
+        assertEquals(42, jobConf.getInt(PxfInputFormat.FILES_LIMIT_PROPERTY, -1));
+    }
+
+    @Test
+    public void testNoFileFragmentsLimitOptionLeavesJobConfUntouched() {
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setDataSource("/some/path");
+
+        HdfsDataFragmenter fragmenter = new HdfsDataFragmenter();
+        fragmenter.setRequestContext(context);
+        fragmenter.afterPropertiesSet();
+
+        JobConf jobConf = fragmenter.getJobConf();
+        assertEquals(-1, jobConf.getInt(PxfInputFormat.FILES_LIMIT_PROPERTY, -1));
     }
 
     private Fragmenter getFragmenter(RequestContext context) {

--- a/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/utilities/PxfInputFormatTest.java
+++ b/server/pxf-hdfs/src/test/java/org/apache/cloudberry/pxf/plugins/hdfs/utilities/PxfInputFormatTest.java
@@ -1,14 +1,21 @@
 package org.apache.cloudberry.pxf.plugins.hdfs.utilities;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InvalidInputException;
+import org.apache.hadoop.mapred.JobConf;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PxfInputFormatTest {
 
@@ -39,5 +46,65 @@ public class PxfInputFormatTest {
 
         boolean result = new PxfInputFormat().isSplitable(fs, path);
         assertEquals(result, expected, description);
+    }
+
+    @Test
+    public void testListingUnderLimit(@TempDir java.nio.file.Path dir) throws IOException {
+        createFiles(dir, "a.csv", "b.csv", "c.json");
+        Files.createFile(dir.resolve("_SUCCESS"));
+
+        FileStatus[] result = listStatus(dir, new Path(dir.toUri()), 10);
+        assertEquals(3, result.length);
+    }
+
+    @Test
+    public void testThrowsWhenLimitExceeded(@TempDir java.nio.file.Path dir) throws IOException {
+        createFiles(dir, "a.csv", "b.csv", "c.csv");
+
+        IOException e = assertThrows(IOException.class,
+                () -> listStatus(dir, new Path(dir.toUri()), 1));
+        assertTrue(e.getMessage().contains("exceeds the configured limit of 1"), e.getMessage());
+        assertTrue(e.getMessage().contains(PxfInputFormat.FILES_LIMIT_OPTION), e.getMessage());
+        assertTrue(e.getMessage().contains(PxfInputFormat.FILES_LIMIT_PROPERTY), e.getMessage());
+    }
+
+    @Test
+    public void testAppliesGlobFilter(@TempDir java.nio.file.Path dir) throws IOException {
+        createFiles(dir, "a.csv", "b.csv", "c.json");
+
+        FileStatus[] result = listStatus(dir, new Path(dir.toUri() + "*.csv"), 10);
+        assertEquals(2, result.length);
+    }
+
+    @Test
+    public void testWildcardMatchingNothingThrows(@TempDir java.nio.file.Path dir) throws IOException {
+        createFiles(dir, "a.csv");
+
+        assertThrows(InvalidInputException.class,
+                () -> listStatus(dir, new Path(dir.toUri() + "*.parquet"), 10));
+    }
+
+    private FileStatus[] listStatus(java.nio.file.Path dir, Path input, int limit) throws IOException {
+        JobConf job = new JobConf(new Configuration());
+        job.setInt(PxfInputFormat.FILES_LIMIT_PROPERTY, limit);
+        FileInputFormat.setInputPaths(job, input);
+        return new LimitedPxfInputFormat().listStatus(job);
+    }
+
+    private void createFiles(java.nio.file.Path dir, String... names) throws IOException {
+        for (String name : names) {
+            Files.createFile(dir.resolve(name));
+        }
+    }
+
+    /**
+     * Forces the streaming limited path so the limit can be exercised against
+     * the local filesystem, which is otherwise gated out as a non-object-store.
+     */
+    private static class LimitedPxfInputFormat extends PxfInputFormat {
+        @Override
+        protected boolean isLimitApplicable(JobConf job) {
+            return true;
+        }
     }
 }

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -116,4 +116,16 @@
         </description>
     </property>
 
+    <property>
+        <name>pxf.fs.fragmenter.files.limit</name>
+        <value>10000000</value>
+        <description>
+            Maximum number of files a single read request may resolve when accessing an object store
+            (S3, GCS, Azure) with the s3:*, gs:*, wasbs:*, and abfss:* profiles. A query whose path or
+            wildcard matches more files than this limit fails fast with an error instead of risking an
+            out-of-memory while listing. Set to 0 or a negative value to disable the limit.
+            Can be overridden per external table with the FILES_LIMIT option.
+        </description>
+    </property>
+
 </configuration>


### PR DESCRIPTION
### Issue

S3 object storage wildcard listing with can match millions of objects, and Hadoop's glob is trying to keep all files' metadata in RAM. This leads to java OOMs:

<img width="2520" height="844" alt="image" src="https://github.com/user-attachments/assets/b190d237-964f-40e3-8503-d984352013b3" />

```
"pxf-response-2" #49 prio=5 os_prio=0 cpu=350100.80ms elapsed=2096.73s tid=0x00007227e8360800 nid=0x37be75 runnable  [0x0000722915ef9000]
   java.lang.Thread.State: RUNNABLE
	at java.net.SocketInputStream.socketRead0(java.base@11.0.30/Native Method)
	<cut>
	at com.amazonaws.services.s3.AmazonS3Client.listObjects(AmazonS3Client.java:928)
	at com.amazonaws.services.s3.AmazonS3Client.listNextBatchOfObjects(AmazonS3Client.java:1000)
	at com.amazonaws.services.s3.AmazonS3Client.listNextBatchOfObjects(AmazonS3Client.java:977)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.continueListObjects(S3AFileSystem.java:1111)
	at org.apache.hadoop.fs.s3a.Listing$ObjectListingIterator.next(Listing.java:588)
	at org.apache.hadoop.fs.s3a.Listing$FileStatusListingIterator.requestNextBatch(Listing.java:416)
	at org.apache.hadoop.fs.s3a.Listing$FileStatusListingIterator.sourceHasNext(Listing.java:371)
	at org.apache.hadoop.fs.s3a.Listing$FileStatusListingIterator.hasNext(Listing.java:367)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.innerListStatus(S3AFileSystem.java:1655)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.listStatus(S3AFileSystem.java:1610)
	at org.apache.hadoop.fs.Globber.listStatus(Globber.java:77)
	at org.apache.hadoop.fs.Globber.doGlob(Globber.java:235)
	at org.apache.hadoop.fs.Globber.glob(Globber.java:149)
	at org.apache.hadoop.fs.FileSystem.globStatus(FileSystem.java:1982)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.globStatus(S3AFileSystem.java:2621)
	at org.apache.hadoop.mapred.FileInputFormat.singleThreadedListStatus(FileInputFormat.java:266)
	at org.apache.hadoop.mapred.FileInputFormat.listStatus(FileInputFormat.java:236)
	at org.greenplum.pxf.plugins.hdfs.utilities.PxfInputFormat.listStatus(PxfInputFormat.java:54)
	at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:322)
	at org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter.getSplits(HdfsDataFragmenter.java:114)
	at org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter.getFragments(HdfsDataFragmenter.java:68)
	at org.greenplum.pxf.service.FragmenterService.lambda$getFragmentsFromCache$0(FragmenterService.java:119)
	at org.greenplum.pxf.service.FragmenterService$$Lambda$1174/0x00007227ddffd8b0.call(Unknown Source)
	at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:64)
	at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:99)
	at org.greenplum.pxf.service.FragmenterService.lambda$getFragmentsFromCache$1(FragmenterService.java:118)
	at org.greenplum.pxf.service.FragmenterService$$Lambda$1171/0x00007227ddfffd08.call(Unknown Source)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4904)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3628)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2336)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2295)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2208)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4053)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4899)
	at org.greenplum.pxf.service.FragmenterService.getFragmentsFromCache(FragmenterService.java:114)
	at org.greenplum.pxf.service.FragmenterService.getFragmentsForSegment(FragmenterService.java:78)
	at org.greenplum.pxf.service.controller.ReadServiceImpl.writeStream(ReadServiceImpl.java:85)
	at org.greenplum.pxf.service.controller.ReadServiceImpl.lambda$readData$0(ReadServiceImpl.java:58)
	at org.greenplum.pxf.service.controller.ReadServiceImpl$$Lambda$1154/0x00007227de1e5900.run(Unknown Source)
	<cut>
	at java.lang.Thread.run(java.base@11.0.30/Thread.java:829)
```

### Solution

In this PR new table-level option `FILES_LIMIT` and system-level option `pxf.fs.fragmenter.files.limit` introduced. This two options controls maximum number of files that Fragmenter can list. In order to use them - simple listing was replaced with `RemoteIterator` and manual `GlobFilter` handling.

Notes:
- Keep old behaviour for HDFS